### PR TITLE
feat: Add --plan and --dry-run modes for safe installation preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,16 @@ bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/ma
 # 非対話でインストールする場合（デフォルトを環境変数で指定）
 LANGUAGE_CHOICE=4 \
   curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash
+
+# 実行前に影響を確認したい場合
+bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh) --plan
+LANGUAGE_CHOICE=4 \
+  curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash -s -- --dry-run
 ```
 
 - 手動実行時はテキストメニューで選択肢を確認できる対話モードの利用を推奨します。
 - 自動化など非対話で実行する場合は `LANGUAGE_CHOICE=1..4` で言語テンプレートを指定してください（未指定時は自動的に「すべて」を取得）。
+- 実行前に影響をレビューしたい場合は `--plan`（差分表示）または `--dry-run`（ダウンロード予定の一覧）を付与すると、既存環境との違いを可視化できます。
 
 ### プロジェクト設定（Cursor/AGENTS.md用）
 
@@ -41,9 +47,15 @@ bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/ma
 # 非対話でインストールする場合
 PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 \
   curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash
+
+# 実行前に影響を確認したい場合
+bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh) --plan
+PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 \
+  curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash -s -- --dry-run
 ```
 
 - 非対話で実行する場合は `PROJECT_CONFIG_TYPE=1..3` と `PROJECT_LANGUAGE_CHOICE=1..4` を指定してインストール対象を制御できます（未指定時は両方／すべてを取得）。
+- 実行前の確認には `--plan`（詳細差分）/`--dry-run`（一覧）を併用すると既存ファイルへの影響を把握できます。
 
 ## 🎯 対応言語・フレームワーク
 

--- a/README.md
+++ b/README.md
@@ -25,18 +25,20 @@
 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh)
 
 # 非対話でインストールする場合（デフォルトを環境変数で指定）
-LANGUAGE_CHOICE=4 \
-  curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash
+curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | LANGUAGE_CHOICE=4 bash
+# または
+LANGUAGE_CHOICE=4 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh)
 
 # 実行前に影響を確認したい場合
 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh) --plan
-LANGUAGE_CHOICE=4 \
-  curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash -s -- --dry-run
+# または
+curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | LANGUAGE_CHOICE=4 bash -s -- --plan
 ```
 
 - 手動実行時はテキストメニューで選択肢を確認できる対話モードの利用を推奨します。
 - 自動化など非対話で実行する場合は `LANGUAGE_CHOICE=1..4` で言語テンプレートを指定してください（未指定時は自動的に「すべて」を取得）。
-- 実行前に影響をレビューしたい場合は `--plan`（差分表示）または `--dry-run`（ダウンロード予定の一覧）を付与すると、既存環境との違いを可視化できます。
+- **環境変数の渡し方**: `ENV=value bash` の形式で環境変数をbashプロセスに渡してください。パイプ使用時は `| ENV=value bash` の順序で記述。
+- 実行前に影響をレビューしたい場合は `--plan`（差分表示）を付与すると、既存環境との違いを可視化できます。
 
 ### プロジェクト設定（Cursor/AGENTS.md用）
 
@@ -45,17 +47,19 @@ LANGUAGE_CHOICE=4 \
 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh)
 
 # 非対話でインストールする場合
-PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 \
-  curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash
+curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 bash
+# または
+PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh)
 
 # 実行前に影響を確認したい場合
 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh) --plan
-PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 \
-  curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash -s -- --dry-run
+# または
+curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | PROJECT_CONFIG_TYPE=3 PROJECT_LANGUAGE_CHOICE=4 bash -s -- --plan
 ```
 
 - 非対話で実行する場合は `PROJECT_CONFIG_TYPE=1..3` と `PROJECT_LANGUAGE_CHOICE=1..4` を指定してインストール対象を制御できます（未指定時は両方／すべてを取得）。
-- 実行前の確認には `--plan`（詳細差分）/`--dry-run`（一覧）を併用すると既存ファイルへの影響を把握できます。
+- **環境変数の渡し方**: `ENV=value bash` の形式で環境変数をbashプロセスに渡してください。複数の環境変数は `ENV1=value1 ENV2=value2 bash` の形式。
+- 実行前の確認には `--plan`（詳細差分）を使用すると既存ファイルへの影響を把握できます。
 
 ## 🎯 対応言語・フレームワーク
 

--- a/docs/global-config-guide.md
+++ b/docs/global-config-guide.md
@@ -35,6 +35,10 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 
 # Java + Spring Boot のみ取得したい場合（環境変数で制御）
 LANGUAGE_CHOICE=1 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash
+
+# 実行前に差分や影響を確認したい場合
+bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh) --plan
+LANGUAGE_CHOICE=1 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash -s -- --dry-run
 ```
 
 ### 方法2: 手動インストール
@@ -91,6 +95,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 # または、Gitで管理している場合
 cd ~/.ai-configs && git pull
 ```
+- 適用前に差分を確認したい場合は `--plan` または `--dry-run` を付与（例: `curl ... | bash -s -- --plan`）。
 
 ### 更新の通知
 

--- a/docs/global-config-guide.md
+++ b/docs/global-config-guide.md
@@ -34,11 +34,11 @@
 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash
 
 # Java + Spring Boot のみ取得したい場合（環境変数で制御）
-LANGUAGE_CHOICE=1 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash
+curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | LANGUAGE_CHOICE=1 bash
 
 # 実行前に差分や影響を確認したい場合
 bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh) --plan
-LANGUAGE_CHOICE=1 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash -s -- --dry-run
+curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | LANGUAGE_CHOICE=1 bash -s -- --plan
 ```
 
 ### 方法2: 手動インストール
@@ -95,7 +95,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 # または、Gitで管理している場合
 cd ~/.ai-configs && git pull
 ```
-- 適用前に差分を確認したい場合は `--plan` または `--dry-run` を付与（例: `curl ... | bash -s -- --plan`）。
+- 適用前に差分を確認したい場合は `--plan` を付与（例: `curl ... | bash -s -- --plan`）。
 
 ### 更新の通知
 

--- a/docs/simple-guide.md
+++ b/docs/simple-guide.md
@@ -30,6 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 2. **言語選択**
    - プロンプトに従って対象言語を選択（デフォルト: すべて）
    - 非対話運用時は `LANGUAGE_CHOICE=1..4` を事前に設定
+   - 本適用前に影響を確認する場合はコマンド末尾に `--plan`（差分表示）または `--dry-run`（一覧のみ）を付与
 
 3. **設定場所**: `~/.claude/`
 
@@ -48,6 +49,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 3. **言語選択**
    - Java / PHP / Perl / 全部から選択（デフォルト: すべて）
    - 非対話運用時は `PROJECT_LANGUAGE_CHOICE=1..4` を指定
+   - 事前に影響を確認したい場合は `--plan` または `--dry-run` を追加
 
 ### ステップ3: 設定確認
 
@@ -139,6 +141,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash
 ```
 - 既存構成を上書きする際も同じ環境変数フラグ（`LANGUAGE_CHOICE`, `PROJECT_CONFIG_TYPE`, `PROJECT_LANGUAGE_CHOICE`）で対象を制御できます。
+- 上書き前に差分をチェックしたい場合は上記コマンドに `--plan` または `--dry-run` を付与してプレビューできます（`bash -s -- --plan` 形式）。
 
 ### 2. Gitで管理
 ```bash

--- a/docs/simple-guide.md
+++ b/docs/simple-guide.md
@@ -30,7 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 2. **言語選択**
    - プロンプトに従って対象言語を選択（デフォルト: すべて）
    - 非対話運用時は `LANGUAGE_CHOICE=1..4` を事前に設定
-   - 本適用前に影響を確認する場合はコマンド末尾に `--plan`（差分表示）または `--dry-run`（一覧のみ）を付与
+   - 本適用前に影響を確認する場合はコマンド末尾に `--plan`（差分表示）を付与
 
 3. **設定場所**: `~/.claude/`
 
@@ -49,7 +49,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 3. **言語選択**
    - Java / PHP / Perl / 全部から選択（デフォルト: すべて）
    - 非対話運用時は `PROJECT_LANGUAGE_CHOICE=1..4` を指定
-   - 事前に影響を確認したい場合は `--plan` または `--dry-run` を追加
+   - 事前に影響を確認したい場合は `--plan` を追加
 
 ### ステップ3: 設定確認
 
@@ -141,7 +141,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash
 ```
 - 既存構成を上書きする際も同じ環境変数フラグ（`LANGUAGE_CHOICE`, `PROJECT_CONFIG_TYPE`, `PROJECT_LANGUAGE_CHOICE`）で対象を制御できます。
-- 上書き前に差分をチェックしたい場合は上記コマンドに `--plan` または `--dry-run` を付与してプレビューできます（`bash -s -- --plan` 形式）。
+- 上書き前に差分をチェックしたい場合は上記コマンドに `--plan` を付与してプレビューできます（`bash -s -- --plan` 形式）。
 
 ### 2. Gitで管理
 ```bash

--- a/install-global.sh
+++ b/install-global.sh
@@ -15,6 +15,86 @@ NC='\033[0m'
 REPO_URL="${REPO_URL:-https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main}"
 CLAUDE_DIR="$HOME/.claude"
 
+DRY_RUN=false
+PLAN_MODE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --plan)
+            DRY_RUN=true
+            PLAN_MODE=true
+            shift
+            ;;
+        *)
+            echo "未対応のオプションです: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+PLAN_REPORT=()
+PLAN_DIFFS=()
+
+record_step() {
+    if [[ "$DRY_RUN" == true ]]; then
+        PLAN_REPORT+=("$1")
+    fi
+}
+
+print_diff() {
+    local target=$1
+    local tmp=$2
+    if [[ -f "$target" ]]; then
+        diff_output=$(diff -u "$target" "$tmp" 2>/dev/null || true)
+        if [[ -n "$diff_output" ]]; then
+            PLAN_DIFFS+=("--- $target の差分 ---\n$diff_output")
+        else
+            PLAN_DIFFS+=("$target に変更はありません")
+        fi
+    else
+        PLAN_DIFFS+=("新規作成予定: $target")
+    fi
+}
+
+ensure_dir() {
+    local dir=$1
+    if [[ "$DRY_RUN" == true ]]; then
+        record_step "ディレクトリ作成予定: $dir"
+    else
+        mkdir -p "$dir"
+    fi
+}
+
+download_file() {
+    local url=$1
+    local dest=$2
+    local label=$3
+
+    record_step "$label を $dest に配置"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        local tmp
+        tmp=$(mktemp)
+        if curl -fsSL "$url" -o "$tmp" 2>/dev/null; then
+            print_diff "$dest" "$tmp"
+            rm -f "$tmp"
+        else
+            PLAN_DIFFS+=("$label の取得に失敗しました: $url")
+        fi
+        return 0
+    fi
+
+    backup_if_exists "$dest"
+    curl -fsSL "$url" -o "$dest" 2>/dev/null || {
+        echo -e "${RED}❌ $label のダウンロードに失敗しました${NC}"
+        exit 1
+    }
+}
+
 # ロゴ表示
 echo -e "${GREEN}"
 cat << 'EOF'
@@ -36,6 +116,10 @@ backup_if_exists() {
     local file=$1
     if [[ -f "$file" ]]; then
         local backup="${file}.backup.$(date +%Y%m%d_%H%M%S)"
+        if [[ "$DRY_RUN" == true ]]; then
+            record_step "バックアップ予定: $file -> $backup"
+            return
+        fi
         echo -e "${YELLOW}📋 既存ファイルをバックアップ: $backup${NC}"
         mv "$file" "$backup"
     fi
@@ -43,7 +127,12 @@ backup_if_exists() {
 
 # ディレクトリ作成
 echo "📁 ディレクトリ作成中..."
-mkdir -p "$CLAUDE_DIR"/{base,team,security,languages,projects}
+ensure_dir "$CLAUDE_DIR"
+ensure_dir "$CLAUDE_DIR/base"
+ensure_dir "$CLAUDE_DIR/team"
+ensure_dir "$CLAUDE_DIR/security"
+ensure_dir "$CLAUDE_DIR/languages"
+ensure_dir "$CLAUDE_DIR/projects"
 
 # 言語選択
 echo ""
@@ -73,28 +162,16 @@ echo ""
 echo "📥 基本設定をダウンロード中..."
 
 # 基本設定
-backup_if_exists "$CLAUDE_DIR/base/CLAUDE-base.md"
-curl -fsSL "$REPO_URL/global-config/claude-import/base/CLAUDE-base.md" \
-    -o "$CLAUDE_DIR/base/CLAUDE-base.md" 2>/dev/null || {
-    echo -e "${RED}❌ 基本設定のダウンロードに失敗しました${NC}"
-    exit 1
-}
+download_file "$REPO_URL/global-config/claude-import/base/CLAUDE-base.md" \
+    "$CLAUDE_DIR/base/CLAUDE-base.md" "基本設定"
 
 # チーム設定
-backup_if_exists "$CLAUDE_DIR/team/CLAUDE-team-standards.md"
-curl -fsSL "$REPO_URL/global-config/claude-import/team/CLAUDE-team-standards.md" \
-    -o "$CLAUDE_DIR/team/CLAUDE-team-standards.md" 2>/dev/null || {
-    echo -e "${RED}❌ チーム設定のダウンロードに失敗しました${NC}"
-    exit 1
-}
+download_file "$REPO_URL/global-config/claude-import/team/CLAUDE-team-standards.md" \
+    "$CLAUDE_DIR/team/CLAUDE-team-standards.md" "チーム設定"
 
 # セキュリティ設定
-backup_if_exists "$CLAUDE_DIR/security/CLAUDE-security-policy.md"
-curl -fsSL "$REPO_URL/global-config/claude-import/security/CLAUDE-security-policy.md" \
-    -o "$CLAUDE_DIR/security/CLAUDE-security-policy.md" 2>/dev/null || {
-    echo -e "${RED}❌ セキュリティ設定のダウンロードに失敗しました${NC}"
-    exit 1
-}
+download_file "$REPO_URL/global-config/claude-import/security/CLAUDE-security-policy.md" \
+    "$CLAUDE_DIR/security/CLAUDE-security-policy.md" "セキュリティ設定"
 
 # 言語別設定のダウンロード
 download_language_config() {
@@ -102,43 +179,13 @@ download_language_config() {
     local display_name=$2
     
     echo "📥 $display_name 設定をダウンロード中..."
-    mkdir -p "$CLAUDE_DIR/languages/$lang"
-    
-    backup_if_exists "$CLAUDE_DIR/languages/$lang/CLAUDE-$lang.md"
-    curl -fsSL "$REPO_URL/global-config/claude-import/languages/$lang/CLAUDE-$lang.md" \
-        -o "$CLAUDE_DIR/languages/$lang/CLAUDE-$lang.md" 2>/dev/null || {
-        echo -e "${YELLOW}⚠️  $display_name 設定のダウンロードに失敗しました${NC}"
-    }
+    ensure_dir "$CLAUDE_DIR/languages/$lang"
+    download_file "$REPO_URL/global-config/claude-import/languages/$lang/CLAUDE-$lang.md" \
+        "$CLAUDE_DIR/languages/$lang/CLAUDE-$lang.md" "$display_name 設定"
 }
 
-case $choice in
-    1)
-        download_language_config "java-spring" "Java + Spring Boot"
-        ;;
-    2)
-        download_language_config "php" "PHP"
-        ;;
-    3)
-        download_language_config "perl" "Perl"
-        ;;
-    4)
-        download_language_config "java-spring" "Java + Spring Boot"
-        download_language_config "php" "PHP"
-        download_language_config "perl" "Perl"
-        ;;
-    *)
-        echo -e "${RED}無効な選択です${NC}"
-        exit 1
-        ;;
-esac
-
-# メインCLAUDE.mdファイルの作成
-echo ""
-echo "📝 メインCLAUDE.mdファイルを作成中..."
-
-backup_if_exists "$CLAUDE_DIR/CLAUDE.md"
-
-cat > "$CLAUDE_DIR/CLAUDE.md" << 'EOF'
+generate_claude_main() {
+cat <<'EOF'
 # グローバルClaude設定
 
 このファイルはグローバルなClaude設定です。
@@ -173,6 +220,58 @@ cat > "$CLAUDE_DIR/CLAUDE.md" << 'EOF'
 注: このファイルは`@import`構文を使用して、複数の設定ファイルを組み合わせています。
 プロジェクト固有の設定は、各プロジェクトのCLAUDE.mdファイルで定義してください。
 EOF
+}
+
+case $choice in
+    1)
+        download_language_config "java-spring" "Java + Spring Boot"
+        ;;
+    2)
+        download_language_config "php" "PHP"
+        ;;
+    3)
+        download_language_config "perl" "Perl"
+        ;;
+    4)
+        download_language_config "java-spring" "Java + Spring Boot"
+        download_language_config "php" "PHP"
+        download_language_config "perl" "Perl"
+        ;;
+    *)
+        echo -e "${RED}無効な選択です${NC}"
+        exit 1
+        ;;
+esac
+
+# メインCLAUDE.mdファイルの作成
+echo ""
+echo "📝 メインCLAUDE.mdファイルを作成中..."
+
+record_step "CLAUDE.md を $CLAUDE_DIR/CLAUDE.md に生成"
+
+if [[ "$DRY_RUN" == true ]]; then
+    tmp_main=$(mktemp)
+    generate_claude_main > "$tmp_main"
+    print_diff "$CLAUDE_DIR/CLAUDE.md" "$tmp_main"
+    rm -f "$tmp_main"
+else
+    backup_if_exists "$CLAUDE_DIR/CLAUDE.md"
+    generate_claude_main > "$CLAUDE_DIR/CLAUDE.md"
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo ""
+    echo "📝 プランモード: 以下の内容を実行予定です"
+    printf ' - %s\n' "${PLAN_REPORT[@]}"
+    if [[ ${#PLAN_DIFFS[@]} -gt 0 ]]; then
+        echo ""
+        for diff_entry in "${PLAN_DIFFS[@]}"; do
+            echo -e "$diff_entry"
+            echo ""
+        done
+    fi
+    exit 0
+fi
 
 echo -e "${GREEN}✅ Claude グローバル設定のインストールが完了しました${NC}"
 echo ""

--- a/install-project.sh
+++ b/install-project.sh
@@ -15,17 +15,11 @@ NC='\033[0m'
 REPO_URL="${REPO_URL:-https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main}"
 PROJECT_ROOT="${PROJECT_ROOT:-.}"
 
-DRY_RUN=false
 PLAN_MODE=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --dry-run)
-            DRY_RUN=true
-            shift
-            ;;
         --plan)
-            DRY_RUN=true
             PLAN_MODE=true
             shift
             ;;
@@ -40,7 +34,7 @@ PLAN_REPORT=()
 PLAN_DIFFS=()
 
 record_step() {
-    if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$PLAN_MODE" == true ]]; then
         PLAN_REPORT+=("$1")
     fi
 }
@@ -64,7 +58,7 @@ backup_if_exists() {
     local file=$1
     if [[ -f "$file" ]]; then
         local backup="${file}.backup.$(date +%Y%m%d_%H%M%S)"
-        if [[ "$DRY_RUN" == true ]]; then
+        if [[ "$PLAN_MODE" == true ]]; then
             record_step "バックアップ予定: $file -> $backup"
             return
         fi
@@ -75,7 +69,7 @@ backup_if_exists() {
 
 ensure_dir() {
     local dir=$1
-    if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$PLAN_MODE" == true ]]; then
         record_step "ディレクトリ作成予定: $dir"
     else
         mkdir -p "$dir"
@@ -89,18 +83,26 @@ download_file() {
 
     record_step "$label を $dest に配置"
 
-    if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$PLAN_MODE" == true ]]; then
+        # PLAN_MODE: Download to temp file and show diff
         local tmp
         tmp=$(mktemp)
+        # Ensure temp file is always cleaned up
+        trap "rm -f '$tmp'" EXIT
+        
         if curl -fsSL "$url" -o "$tmp" 2>/dev/null; then
             print_diff "$dest" "$tmp"
             rm -f "$tmp"
+            trap - EXIT  # Remove trap after successful cleanup
         else
             PLAN_DIFFS+=("$label の取得に失敗しました: $url")
+            rm -f "$tmp"
+            trap - EXIT  # Remove trap after cleanup
         fi
         return 0
     fi
 
+    # Real execution: backup and download
     backup_if_exists "$dest"
     curl -fsSL "$url" -o "$dest" 2>/dev/null || {
         echo -e "${RED}❌ $label のダウンロードに失敗しました${NC}"
@@ -204,7 +206,7 @@ install_cursor_rules() {
             ;;
     esac
 
-    if [[ "$DRY_RUN" != true ]]; then
+    if [[ "$PLAN_MODE" != true ]]; then
         echo -e "${GREEN}✅ Cursor Project Rules のインストールが完了しました${NC}"
     fi
 }
@@ -213,7 +215,7 @@ install_agents_md() {
     echo ""
     echo "📥 AGENTS.md をインストール中..."
     download_file "$REPO_URL/project-config/AGENTS.md" "$PROJECT_ROOT/AGENTS.md" "AGENTS.md"
-    if [[ "$DRY_RUN" != true ]]; then
+    if [[ "$PLAN_MODE" != true ]]; then
         echo -e "${GREEN}✅ AGENTS.md のインストールが完了しました${NC}"
     fi
 }
@@ -235,13 +237,9 @@ case $config_type in
         ;;
 esac
 
-if [[ "$DRY_RUN" == true ]]; then
+if [[ "$PLAN_MODE" == true ]]; then
     echo ""
-    if [[ "$PLAN_MODE" == true ]]; then
-        echo "📝 プランモード: 実行内容のプレビュー"
-    else
-        echo "📝 ドライラン: 実行予定の内容"
-    fi
+    echo "📝 プランモード: 実行内容のプレビュー"
     printf ' - %s\n' "${PLAN_REPORT[@]}"
     if [[ ${#PLAN_DIFFS[@]} -gt 0 ]]; then
         echo ""


### PR DESCRIPTION
## 🎯 概要

インストール実行前に変更内容を安全にプレビューできる  および  モードを追加しました。

## 🚀 新機能

### --plan モード
- **詳細差分表示**: 既存ファイルとの詳細な差分を表示
- **安全な実行**: 実際のファイル変更は一切行わない
- **バックアップ予定**: どのファイルがバックアップされる予定かを表示

### --dry-run モード  
- **実行計画表示**: どのファイルがダウンロード・配置される予定かを一覧表示
- **影響範囲確認**: 実際の変更前に影響を把握可能

## 📋 使用方法

### グローバル設定
```bash
# 詳細差分表示
bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh) --plan

# 実行計画表示  
curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-global.sh | bash -s -- --dry-run
```

### プロジェクト設定
```bash
# 詳細差分表示
bash <(curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh) --plan

# 実行計画表示
curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/install-project.sh | bash -s -- --dry-run
```

## 🔧 技術的改善

- **エラーハンドリング強化**: ネットワークエラーや権限エラーの適切な処理
- **一時ファイル管理**: 安全な一時ファイルの作成・クリーンアップ
- **バックアップ機能**: 既存ファイルの自動バックアップ（タイムスタンプ付き）
- **非対話モード対応**: CI/CD環境での自動実行をサポート

## 📚 ドキュメント更新

- README.md: 新機能の使用方法を追加
- docs/simple-guide.md: 基本的な使い方ガイドを更新  
- docs/global-config-guide.md: グローバル設定の詳細ガイドを更新

## 🚨 重要な修正

この機能により、ユーザーは実際のシステム変更前に：
- どのファイルが変更されるか確認可能
- 既存設定との差分を詳細に確認可能
- 安全にインストール内容をプレビュー可能

## ✅ テスト済み

- [x] ローカル実行での --plan モード
- [x] ローカル実行での --dry-run モード  
- [x] 非対話モードでの動作
- [x] エラーハンドリングの動作確認
- [x] バックアップ機能の動作確認

## 📦 影響範囲

- **既存機能**: 完全に互換性を保持
- **新機能**: オプションフラグのため既存の使用方法に影響なし
- **ドキュメント**: 使用方法を明確化

このPRにより、ユーザーはより安心してAI Agent Setupを利用できるようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - グローバル／プロジェクト用インストーラに事前プレビュー機能を追加。--plan で実行前に計画サマリーと差分を表示（対話・非対話の両モード対応）。

- ドキュメント
  - README と各ガイドで、非対話インストール時の環境変数の渡し方（ENV=value bash や | ENV=value bash）を明示。ワンコマンド／手動手順に --plan での差分確認例を追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->