### PR TITLE
feat: changelog-generatorスキル・エージェントを追加

### DIFF
--- a/.claude/agents/changelog-generator/AGENT.md
+++ b/.claude/agents/changelog-generator/AGENT.md
@@ -1,0 +1,648 @@
+---
+name: changelog-generator
+description: |
+  CHANGELOGとリリースノート自動生成エージェント。
+  git/jjコミット履歴からConventional Commits形式を解析し、
+  Keep a Changelog形式のCHANGELOG.mdを生成・更新する。
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit
+---
+
+# CHANGELOG生成エージェント
+
+## 目的
+
+プロジェクトのgit/jujutsuコミット履歴を解析し、以下を自動生成する：
+
+1. **CHANGELOG.md**: Keep a Changelog形式の変更履歴
+2. **リリースノート**: GitHub Releases用のマーケティング的な説明
+3. **バージョン提案**: Semantic Versioningに基づく次期バージョン
+
+## 前提条件
+
+### 必須
+- Git/Jujutsuリポジトリであること
+- コミット履歴が存在すること
+
+### 推奨
+- Conventional Commitsに従ったコミットメッセージ
+- タグでバージョン管理されていること
+- `gh` CLI（GitHub Releases作成時）
+
+## 参照すべきスキル
+
+実行前に必ず `.claude/skills/changelog/SKILL.md` を確認すること。
+
+**重要な参照情報**：
+- Keep a Changelog形式（6カテゴリ：Added, Changed, Deprecated, Removed, Fixed, Security）
+- Conventional Commits仕様（feat, fix, docs, style, refactor, perf, test, build, ci, chore）
+- Semantic Versioning（MAJOR.MINOR.PATCH）
+- Breaking Changes判定（`!` または `BREAKING CHANGE:`）
+
+## 実行フロー
+
+### Phase 1: プロジェクト情報収集
+
+#### 1.1 リポジトリタイプ検出
+
+```bash
+# Gitリポジトリか確認
+if [ -d .git ]; then
+    echo "Git repository detected"
+    VCS="git"
+elif [ -d .jj ]; then
+    echo "Jujutsu repository detected"
+    VCS="jj"
+else
+    echo "Error: Not a version control repository"
+    exit 1
+fi
+```
+
+#### 1.2 最新タグ取得
+
+```bash
+# Gitの場合
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+# Jujutsuの場合
+# jjにはタグ概念がないため、git backendのタグを参照
+LATEST_TAG=$(jj git fetch --all-remotes 2>/dev/null && git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [ -z "$LATEST_TAG" ]; then
+    echo "No tags found. This will be the initial release."
+    RANGE="--all"
+else
+    echo "Latest tag: $LATEST_TAG"
+    RANGE="$LATEST_TAG..HEAD"
+fi
+```
+
+#### 1.3 既存CHANGELOG確認
+
+```bash
+# Readツールで既存CHANGELOGを読み取る
+if [ -f CHANGELOG.md ]; then
+    # 既存の[Unreleased]セクションを確認
+    # 手動で追加された項目があるか確認
+fi
+```
+
+### Phase 2: コミット履歴解析
+
+#### 2.1 コミットメッセージ収集
+
+```bash
+# Gitの場合
+git log $RANGE --pretty=format:"%H|%s|%b|%an|%ad" --date=short
+
+# Jujutsuの場合
+jj log -r "$RANGE" --template 'change_id ++ "|" ++ description ++ "|" ++ author ++ "|" ++ committer_date'
+```
+
+#### 2.2 Conventional Commits解析
+
+各コミットメッセージを以下のパターンでパース：
+
+```regex
+^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(([^)]+)\))?(!)?:\s*(.+)$
+```
+
+**マッピング規則**：
+
+| Type | Scope | Breaking | → Category |
+|------|-------|----------|------------|
+| `feat` | any | no | Added |
+| `feat` | any | yes | Changed + BREAKING |
+| `fix` | any | no | Fixed |
+| `perf` | any | no | Changed |
+| `refactor` | any | no | （記載しない）|
+| `docs` | any | no | （記載しない）|
+| `test` | any | no | （記載しない）|
+| security | any | no | Security |
+
+**Breaking Change判定**：
+1. `type!:` 形式（例：`feat!: drop Node 14`）
+2. フッターに `BREAKING CHANGE:` が含まれる
+
+#### 2.3 カテゴリ分類
+
+```json
+{
+  "added": [],
+  "changed": [],
+  "deprecated": [],
+  "removed": [],
+  "fixed": [],
+  "security": [],
+  "breaking_changes": []
+}
+```
+
+### Phase 3: バージョン決定
+
+#### 3.1 Semantic Versioning判定
+
+現在のバージョンが `v1.2.3` の場合：
+
+| 条件 | 次期バージョン |
+|------|---------------|
+| Breaking Changeあり | `v2.0.0` (MAJOR) |
+| `feat` あり（Breaking なし） | `v1.3.0` (MINOR) |
+| `fix` のみ | `v1.2.4` (PATCH) |
+| コミットなし | バージョンアップ不要 |
+
+#### 3.2 ユーザー確認
+
+**重要**: バージョン番号は必ずユーザーに確認する。
+
+```
+提案バージョン: v2.0.0
+理由: Breaking Changeが2件含まれています
+
+- feat(api)!: change response format
+- feat(auth)!: drop OAuth1 support
+
+このバージョンで問題ないですか？
+```
+
+### Phase 4: CHANGELOG生成
+
+#### 4.1 [Unreleased]セクション作成
+
+Keep a Changelog形式に従う：
+
+```markdown
+## [Unreleased]
+
+### Added
+- OAuth2 login support (#123)
+- Dark mode toggle in settings
+
+### Changed
+- **BREAKING**: User API response format changed
+- Improved authentication performance by 50%
+
+### Fixed
+- Fixed crash on null user data (#456)
+- Resolved button alignment issue
+```
+
+#### 4.2 リリースセクション作成
+
+ユーザーが承認したら、`[Unreleased]` を正式バージョンに変換：
+
+```markdown
+## [2.0.0] - 2024-12-04
+
+### Added
+- OAuth2 login support (#123)
+- Dark mode toggle in settings
+
+### Changed
+- **BREAKING**: User API response format changed
+- Improved authentication performance by 50%
+
+### Fixed
+- Fixed crash on null user data (#456)
+- Resolved button alignment issue
+
+## [Unreleased]
+
+（次の開発サイクル用に空のセクションを用意）
+```
+
+#### 4.3 ファイル更新
+
+**既存CHANGELOGがある場合**: Editツールで更新
+
+```markdown
+# 既存の[Unreleased]セクションを新バージョンに置換
+# 新しい[Unreleased]セクションを追加
+# フッターのリンクを更新
+```
+
+**既存CHANGELOGがない場合**: Writeツールで新規作成
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2024-12-04
+
+### Added
+- Initial release
+
+[Unreleased]: https://github.com/user/repo/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/user/repo/releases/tag/v1.0.0
+```
+
+### Phase 5: リリースノート生成（オプション）
+
+#### 5.1 マーケティング的なリリースノート
+
+CHANGELOG.mdとは別に、よりユーザーフレンドリーな形式で作成：
+
+```markdown
+# Version 2.0.0 - Major Update! 🎉
+
+We're excited to announce Version 2.0 with significant improvements!
+
+## 🚀 Highlights
+
+- **Modern Authentication**: New OAuth2 support for Google and GitHub login
+- **Dark Mode**: Beautiful dark theme now available
+- **Performance**: 50% faster authentication
+
+## 💥 Breaking Changes
+
+This release includes breaking changes. Please review the migration guide:
+
+- User API response format has changed
+- OAuth1 support has been removed
+
+See [MIGRATION.md](MIGRATION.md) for upgrade instructions.
+
+## 🐛 Bug Fixes
+
+- Fixed crash when user data is null
+- Resolved UI alignment issues
+
+## 📖 Full Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for complete details.
+
+## 🙏 Contributors
+
+Thanks to @user1, @user2 for their contributions!
+```
+
+#### 5.2 GitHub Release作成支援
+
+```bash
+# ユーザーに確認
+echo "GitHub Releaseを作成しますか？ (y/n)"
+
+# yesの場合
+gh release create v2.0.0 \
+  --title "Version 2.0.0 - Major Update" \
+  --notes-file RELEASE_NOTES.md \
+  --target main
+
+# Breaking Changeがある場合は警告を追加
+if [ "$HAS_BREAKING" = "true" ]; then
+    gh release edit v2.0.0 --notes "⚠️ **Breaking Changes** - See migration guide"
+fi
+```
+
+### Phase 6: 検証と確認
+
+#### 6.1 生成ファイル確認
+
+```bash
+# 生成されたファイルをユーザーに表示
+echo "=== 生成されたファイル ==="
+echo "1. CHANGELOG.md"
+cat CHANGELOG.md | head -50
+
+echo "2. RELEASE_NOTES.md（オプション）"
+if [ -f RELEASE_NOTES.md ]; then
+    cat RELEASE_NOTES.md
+fi
+```
+
+#### 6.2 次のアクション提案
+
+```
+✅ CHANGELOG生成完了
+
+次のステップ：
+1. CHANGELOG.mdの内容を確認
+2. 必要に応じて手動で調整
+3. git/jj でコミット:
+   git add CHANGELOG.md
+   git commit -m "docs: update CHANGELOG for v2.0.0"
+   git tag -a v2.0.0 -m "Release version 2.0.0"
+   git push origin v2.0.0
+
+4. GitHub Releaseを作成（オプション）:
+   gh release create v2.0.0 --notes-file RELEASE_NOTES.md
+```
+
+## 安全性ルール
+
+### 1. 自動git操作の禁止
+
+**絶対に自動実行してはいけない**：
+- `git commit`
+- `git tag`
+- `git push`
+- `gh release create`
+
+すべてユーザーの明示的な指示を待つこと。
+
+### 2. ファイル上書き確認
+
+既存のCHANGELOG.mdを更新する場合：
+```
+既存のCHANGELOG.mdが見つかりました。
+[Unreleased]セクションを更新します。
+よろしいですか？ (y/n)
+```
+
+### 3. Breaking Change警告
+
+Breaking Changeが含まれる場合は明示的に警告：
+```
+⚠️ 警告: Breaking Changeが含まれています
+
+以下のコミットが破壊的変更を含みます：
+- feat(api)!: change response format
+- feat(auth)!: drop OAuth1 support
+
+これによりメジャーバージョンがアップします: v1.x.x → v2.0.0
+MIGRATION.mdの作成を推奨します。
+```
+
+### 4. バージョン番号の検証
+
+提案されたバージョン番号が妥当か確認：
+```
+現在: v1.2.3
+提案: v2.0.0
+
+この変更は妥当ですか？
+- MAJOR: Breaking Changeあり ✓
+- MINOR: 新機能あり ✓
+- PATCH: バグ修正あり ✓
+```
+
+## 自動生成ツール連携
+
+### conventional-changelog（Node.js）
+
+プロジェクトに `conventional-changelog-cli` がインストールされている場合：
+
+```bash
+# インストール確認
+if command -v conventional-changelog &> /dev/null; then
+    echo "conventional-changelog-cli detected"
+
+    # CHANGELOGを自動生成
+    conventional-changelog -p angular -i CHANGELOG.md -s
+else
+    echo "conventional-changelog-cli not found. Using manual generation."
+fi
+```
+
+### standard-version（Node.js）
+
+```bash
+# package.jsonにstandard-versionがある場合
+if grep -q "standard-version" package.json 2>/dev/null; then
+    echo "standard-version detected"
+    echo "Run: npm run release"
+    echo "または: npx standard-version"
+fi
+```
+
+### git-chglog（Go）
+
+```bash
+# git-chglogの設定ファイル確認
+if [ -f .chglog/config.yml ]; then
+    echo "git-chglog config found"
+
+    # CHANGELOGを自動生成
+    git-chglog -o CHANGELOG.md
+fi
+```
+
+## トラブルシューティング
+
+### Q1: Conventional Commitsに従っていないコミットがある
+
+**対処法**:
+```bash
+# パターンマッチしないコミットを除外
+git log --grep="^feat\|^fix\|^docs" --pretty=format:"%s"
+
+# または手動でカテゴリ分類を提案
+echo "以下のコミットはConventional Commitsに従っていません："
+echo "- Update README"
+echo "- Bug fix"
+echo ""
+echo "どのカテゴリに分類しますか？"
+echo "1. Added (新機能)"
+echo "2. Fixed (バグ修正)"
+echo "3. Changed (変更)"
+echo "4. 無視"
+```
+
+### Q2: マージコミットが多い
+
+**対処法**:
+```bash
+# マージコミットを除外
+git log --no-merges $RANGE --pretty=format:"%s"
+```
+
+### Q3: タグが存在しない（初回リリース）
+
+**対処法**:
+```bash
+# 全コミット履歴から生成
+echo "タグが見つかりません。初回リリースとして処理します。"
+git log --all --pretty=format:"%s"
+
+# 初回リリース用のCHANGELOG
+## [1.0.0] - 2024-12-04
+
+### Added
+- Initial release
+```
+
+### Q4: Breaking Changeの誤検出
+
+**対処法**:
+```
+以下をBreaking Changeとして検出しました：
+- feat(api)!: update endpoint
+
+これは本当に破壊的変更ですか？
+1. はい（MAJOR バージョンアップ）
+2. いいえ（MINOR バージョンアップ）
+```
+
+## 出力例
+
+### 例1: 通常のマイナーバージョンアップ
+
+**入力コミット**:
+```
+feat(auth): add OAuth2 support
+fix(ui): resolve button alignment
+docs: update README
+```
+
+**生成されたCHANGELOG**:
+```markdown
+## [1.3.0] - 2024-12-04
+
+### Added
+- OAuth2 authentication support
+
+### Fixed
+- Button alignment issue in settings page
+```
+
+### 例2: Breaking Changeを含むメジャーバージョンアップ
+
+**入力コミット**:
+```
+feat(api)!: change user endpoint response format
+
+BREAKING CHANGE: User endpoint now returns nested object.
+
+Before: { "name": "John" }
+After: { "user": { "name": "John" } }
+```
+
+**生成されたCHANGELOG**:
+```markdown
+## [2.0.0] - 2024-12-04
+
+### Changed
+- **BREAKING**: User endpoint response format changed to nested structure
+
+### Migration Guide
+
+Update your API client code:
+
+**Before**:
+```js
+const name = response.name;
+```
+
+**After**:
+```js
+const name = response.user.name;
+```
+```
+
+### 例3: セキュリティ修正
+
+**入力コミット**:
+```
+fix(auth): prevent SQL injection in login
+security: update dependencies with known CVEs
+```
+
+**生成されたCHANGELOG**:
+```markdown
+## [1.2.1] - 2024-12-04
+
+### Fixed
+- SQL injection vulnerability in authentication
+
+### Security
+- Updated dependencies with security vulnerabilities (CVE-2024-XXXX)
+```
+
+## ベストプラクティス
+
+### 1. ユーザー視点の記述
+
+```markdown
+# ❌ 悪い例
+- Refactored AuthService class
+- Changed database query from N+1 to eager loading
+
+# ✅ 良い例
+- Improved login response time by 50%
+- Fixed slow user list loading
+```
+
+### 2. issueとPRのリンク
+
+```markdown
+### Fixed
+- Fixed authentication timeout (#123, @username)
+- Resolved crash on startup (PR #456)
+```
+
+### 3. マイグレーションガイド
+
+Breaking Changeがある場合は必ずマイグレーションガイドを提供：
+
+```markdown
+## [2.0.0] - 2024-12-04
+
+### Changed
+- **BREAKING**: Minimum Node.js version is now 16
+
+### Migration Guide
+
+1. Update Node.js:
+   ```bash
+   nvm install 16
+   nvm use 16
+   ```
+
+2. Update dependencies:
+   ```bash
+   npm install
+   ```
+```
+
+## GitHub Actions連携
+
+CHANGELOG生成をCI/CDに組み込む例：
+
+```yaml
+name: Generate Changelog
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Generate CHANGELOG
+        run: |
+          # conventional-changelogまたはgit-chglogを使用
+          npx conventional-changelog -p angular -i CHANGELOG.md -s
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body_path: CHANGELOG.md
+```
+
+## まとめ
+
+このエージェントは以下を自動化する：
+
+✅ git/jjコミット履歴の解析
+✅ Conventional Commitsの分類
+✅ Keep a Changelog形式の生成
+✅ Semantic Versioningの適用
+✅ GitHub Releases用リリースノート作成
+
+**重要**: すべてのgit操作はユーザー確認が必須。自動実行しない。

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,480 @@
+---
+name: changelog
+description: |
+  CHANGELOGとリリースノート生成ガイド。
+  Conventional Commits、Keep a Changelog形式、セマンティックバージョニング対応。
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# CHANGELOG生成スキル
+
+## 目的
+
+プロジェクトの変更履歴を適切に管理し、ユーザーにとって有用なCHANGELOGとリリースノートを生成する。
+
+## CHANGELOG形式
+
+### Keep a Changelog形式（推奨）
+
+[Keep a Changelog](https://keepachangelog.com/)に準拠した形式：
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- 新機能A
+- 新機能B
+
+### Changed
+- 変更された機能C
+
+### Deprecated
+- 非推奨となった機能D
+
+### Removed
+- 削除された機能E
+
+### Fixed
+- 修正されたバグF
+
+### Security
+- セキュリティ修正G
+
+## [1.0.0] - 2024-01-15
+
+### Added
+- 初回リリース
+- 基本機能の実装
+
+[Unreleased]: https://github.com/user/repo/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/user/repo/releases/tag/v1.0.0
+```
+
+### カテゴリの意味
+
+| カテゴリ | 説明 | 例 |
+|---------|------|-----|
+| **Added** | 新機能 | 新しいAPI、新しいコマンド |
+| **Changed** | 既存機能の変更 | パラメータ変更、デフォルト値変更 |
+| **Deprecated** | 非推奨（将来削除予定） | 古いAPI、レガシー機能 |
+| **Removed** | 削除された機能 | 非推奨だった機能の削除 |
+| **Fixed** | バグ修正 | クラッシュ修正、表示バグ修正 |
+| **Security** | セキュリティ修正 | 脆弱性対応、CVE修正 |
+
+## Conventional Commits
+
+### フォーマット
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### タイプ一覧
+
+| Type | 説明 | CHANGELOGカテゴリ |
+|------|------|------------------|
+| `feat` | 新機能 | Added |
+| `fix` | バグ修正 | Fixed |
+| `docs` | ドキュメントのみ | - |
+| `style` | コードの意味に影響しない変更 | - |
+| `refactor` | リファクタリング | - |
+| `perf` | パフォーマンス改善 | Changed |
+| `test` | テスト追加・修正 | - |
+| `build` | ビルドシステム変更 | - |
+| `ci` | CI設定変更 | - |
+| `chore` | その他の変更 | - |
+| `revert` | コミットの取り消し | - |
+
+### Breaking Changes
+
+**BREAKING CHANGE** を含むコミットはメジャーバージョンアップの対象：
+
+```
+feat!: drop support for Node 14
+
+BREAKING CHANGE: Node 14 is no longer supported. Minimum version is Node 16.
+```
+
+### 例
+
+#### 新機能
+```
+feat(auth): add OAuth2 login support
+
+Implemented OAuth2 authentication flow with Google and GitHub providers.
+Closes #123
+```
+
+#### バグ修正
+```
+fix(api): handle null response in user endpoint
+
+Fixed crash when user data is null.
+Fixes #456
+```
+
+#### 破壊的変更
+```
+feat(api)!: change user endpoint response format
+
+BREAKING CHANGE: User endpoint now returns nested user object instead of flat structure.
+
+Before:
+{ "name": "John", "email": "john@example.com" }
+
+After:
+{ "user": { "name": "John", "email": "john@example.com" } }
+```
+
+## セマンティックバージョニング
+
+### バージョン形式
+
+```
+MAJOR.MINOR.PATCH
+
+例: 1.2.3
+```
+
+### バージョンアップルール
+
+| 変更内容 | バージョン | 例 |
+|---------|-----------|-----|
+| **破壊的変更** | MAJOR | 1.0.0 → 2.0.0 |
+| **新機能（後方互換）** | MINOR | 1.0.0 → 1.1.0 |
+| **バグ修正** | PATCH | 1.0.0 → 1.0.1 |
+
+### プレリリース
+
+```
+1.0.0-alpha.1    # アルファ版
+1.0.0-beta.2     # ベータ版
+1.0.0-rc.1       # リリース候補
+```
+
+## git logからの情報抽出
+
+### コミットメッセージ取得
+
+```bash
+# 最新タグから現在までのコミット
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+
+# 特定の期間のコミット
+git log --since="2024-01-01" --until="2024-01-31" --pretty=format:"%h - %s (%an, %ad)" --date=short
+
+# Conventional Commits形式でフィルタ
+git log --pretty=format:"%s" | grep -E "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?:"
+```
+
+### タグ情報取得
+
+```bash
+# すべてのタグを日付順で表示
+git tag -l --sort=-version:refname
+
+# タグ間の差分
+git log v1.0.0..v1.1.0 --oneline
+
+# タグの作成日時
+git log --tags --simplify-by-decoration --pretty="format:%ai %d"
+```
+
+### PR情報の抽出
+
+```bash
+# GitHub CLIでPR情報取得
+gh pr list --state merged --limit 100 --json number,title,mergedAt,labels
+
+# マージされたPRのコミット取得
+gh pr view 123 --json commits
+```
+
+## 自動生成ツール
+
+### conventional-changelog（Node.js）
+
+```bash
+# インストール
+npm install -g conventional-changelog-cli
+
+# CHANGELOG生成
+conventional-changelog -p angular -i CHANGELOG.md -s
+
+# 初回生成（全履歴）
+conventional-changelog -p angular -i CHANGELOG.md -s -r 0
+```
+
+### standard-version（Node.js）
+
+```bash
+# インストール
+npm install -g standard-version
+
+# バージョンアップ + CHANGELOG生成
+standard-version
+
+# 初回リリース
+standard-version --first-release
+
+# プレリリース
+standard-version --prerelease alpha
+```
+
+### git-chglog（Go）
+
+```bash
+# インストール
+brew install git-chglog
+
+# 初期設定
+git-chglog --init
+
+# CHANGELOG生成
+git-chglog -o CHANGELOG.md
+
+# 特定バージョン
+git-chglog v1.0.0..v1.1.0
+```
+
+## CHANGELOGのベストプラクティス
+
+### 1. ユーザー視点で書く
+
+```markdown
+# ❌ 悪い例
+- Refactored UserService class
+
+# ✅ 良い例
+- Improved user authentication performance by 50%
+```
+
+### 2. 技術的詳細は控えめに
+
+```markdown
+# ❌ 悪い例
+- Changed database query from N+1 to eager loading with includes
+
+# ✅ 良い例
+- Fixed slow user list loading (reduced from 5s to 0.5s)
+```
+
+### 3. 破壊的変更は明示
+
+```markdown
+## [2.0.0] - 2024-01-15
+
+### Changed
+- **BREAKING**: Minimum Node.js version is now 16
+- **BREAKING**: User API endpoint response format changed
+
+### Migration Guide
+See [MIGRATION.md](MIGRATION.md) for upgrade instructions.
+```
+
+### 4. issueとPRをリンク
+
+```markdown
+### Fixed
+- Fixed authentication timeout (#123, @username)
+- Resolved crash on startup (PR #456)
+```
+
+### 5. 日付形式の統一
+
+```markdown
+# ISO 8601形式（推奨）
+## [1.0.0] - 2024-01-15
+
+# または
+## [1.0.0] - 2024-01-15T10:30:00Z
+```
+
+## リリースノート vs CHANGELOG
+
+### CHANGELOG.md
+- **対象**: 開発者、技術者
+- **内容**: すべての変更を時系列で記録
+- **形式**: Keep a Changelog
+- **更新頻度**: 各リリースごと
+
+### Release Notes（GitHub Releases等）
+- **対象**: エンドユーザー、プロダクトマネージャー
+- **内容**: 主要な変更、ハイライト
+- **形式**: よりマーケティング寄り
+- **更新頻度**: 重要なリリースのみ
+
+### リリースノートの例
+
+```markdown
+# Version 2.0.0 - Major Update! 🎉
+
+We're excited to announce Version 2.0 with significant improvements!
+
+## 🚀 New Features
+- **OAuth2 Support**: Sign in with Google and GitHub
+- **Dark Mode**: New dark theme option in settings
+- **Performance**: 3x faster page load times
+
+## 💥 Breaking Changes
+- Minimum Node.js version is now 16
+- API response format has changed (see migration guide)
+
+## 🐛 Bug Fixes
+- Fixed crash on startup
+- Resolved authentication timeout issues
+
+## 📖 Documentation
+Full changelog: [CHANGELOG.md](CHANGELOG.md)
+Migration guide: [MIGRATION.md](MIGRATION.md)
+
+## 🙏 Contributors
+Thanks to @user1, @user2, @user3 for their contributions!
+```
+
+## GitHub Releasesとの連携
+
+### gh CLIでリリース作成
+
+```bash
+# リリース作成
+gh release create v1.0.0 \
+  --title "Version 1.0.0" \
+  --notes-file RELEASE_NOTES.md
+
+# CHANGELOGから自動生成
+gh release create v1.0.0 \
+  --generate-notes
+
+# プレリリース
+gh release create v1.0.0-beta.1 \
+  --prerelease \
+  --notes "Beta release for testing"
+```
+
+### リリースノートの自動生成
+
+GitHub Actionsでの自動化：
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Generate Changelog
+        id: changelog
+        run: |
+          echo "## What's Changed" > release_notes.md
+          git log $(git describe --tags --abbrev=0 HEAD^)..HEAD --pretty=format:"- %s (%h)" >> release_notes.md
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body_path: release_notes.md
+```
+
+## CHANGELOGメンテナンスのワークフロー
+
+### 1. 開発中
+
+```bash
+# Conventional Commitsでコミット
+git commit -m "feat(auth): add OAuth2 support"
+git commit -m "fix(ui): resolve button alignment issue"
+```
+
+### 2. リリース準備
+
+```bash
+# CHANGELOGを自動生成
+conventional-changelog -p angular -i CHANGELOG.md -s
+
+# または
+standard-version
+
+# 手動で編集（必要に応じて）
+vim CHANGELOG.md
+```
+
+### 3. リリース
+
+```bash
+# タグ作成
+git tag -a v1.0.0 -m "Release version 1.0.0"
+
+# プッシュ
+git push origin v1.0.0
+
+# GitHub Releasesを作成
+gh release create v1.0.0 --notes-file RELEASE_NOTES.md
+```
+
+### 4. リリース後
+
+```bash
+# 次の開発サイクル開始
+# CHANGELOG.mdの[Unreleased]セクションに新しい変更を追加
+```
+
+## トラブルシューティング
+
+### Q: Conventional Commitsに従っていない古いコミットがある
+
+**A**: 手動でCHANGELOGを編集するか、フィルタリングする
+
+```bash
+# 特定のパターンにマッチするコミットのみ抽出
+git log --grep="^feat\|^fix" --pretty=format:"%s"
+```
+
+### Q: マージコミットが多くてノイズになる
+
+**A**: `--no-merges`オプションを使用
+
+```bash
+git log --no-merges --oneline
+```
+
+### Q: リリースごとにバージョン番号を決めるのが大変
+
+**A**: semantic-releaseを使用した完全自動化
+
+```bash
+npm install -g semantic-release-cli
+semantic-release-cli setup
+```
+
+## 参考資料
+
+- [Keep a Changelog](https://keepachangelog.com/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
+- [standard-version](https://github.com/conventional-changelog/standard-version)
+- [semantic-release](https://github.com/semantic-release/semantic-release)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **stable-version**: LTS/EOL管理、バージョンアップグレード判断
 - **e2e-first-planning**: Walking Skeleton、MVP計画策定
 - **design-review**: アクセシビリティ、レスポンシブ、パフォーマンス評価
+- **changelog**: CHANGELOG/リリースノート生成、Conventional Commits、SemVer
 - **java-spring**: Java + Spring Boot開発支援
 - **php**: PHP開発支援
 - **perl**: Perl開発支援
@@ -36,6 +37,7 @@
 - **stable-version-auditor**: 技術スタックバージョン監査、リスク評価
 - **e2e-first-planner**: E2E開発計画の自動生成
 - **design-reviewer**: UI/UXデザインの自動レビュー
+- **changelog-generator**: CHANGELOG.md自動生成、GitHub Releases作成支援
 
 ## 🚀 クイックスタート
 
@@ -112,6 +114,7 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 │   ├── stable-version/SKILL.md # バージョン管理ガイド
 │   ├── e2e-first-planning/SKILL.md # E2E計画ガイド
 │   ├── design-review/SKILL.md  # デザインレビューガイド
+│   ├── changelog/SKILL.md      # CHANGELOG生成ガイド
 │   ├── java-spring/SKILL.md    # Java開発支援
 │   ├── php/SKILL.md            # PHP開発支援
 │   ├── perl/SKILL.md           # Perl開発支援
@@ -121,7 +124,8 @@ curl -fsSL https://raw.githubusercontent.com/sk8metalme/ai-agent-setup/main/inst
 │   ├── oss-license-checker/AGENT.md # ライセンス監査
 │   ├── stable-version-auditor/AGENT.md # バージョン監査
 │   ├── e2e-first-planner/AGENT.md # E2E計画生成
-│   └── design-reviewer/AGENT.md # デザインレビュー
+│   ├── design-reviewer/AGENT.md # デザインレビュー
+│   └── changelog-generator/AGENT.md # CHANGELOG生成
 └── languages/
     ├── java-spring/CLAUDE-java-spring.md
     ├── php/CLAUDE-php.md
@@ -252,6 +256,7 @@ my-project/
 - **stable-version**: LTS判断、EOL対応、endoflife.date API活用
 - **e2e-first-planning**: Walking Skeleton → MVP、縦割りタスク分割
 - **design-review**: WCAG 2.1 AA、Core Web Vitals、レスポンシブ確認
+- **changelog**: Keep a Changelog形式、Conventional Commits、SemVer、自動生成ツール（conventional-changelog/standard-version/git-chglog）
 - **言語別スキル**: Java/PHP/Perl/Python開発のベストプラクティス
 
 #### エージェント（実行アシスタント）
@@ -260,6 +265,7 @@ my-project/
 - **stable-version-auditor**: 技術スタック検出、リスク評価（Critical/Warning/Info）
 - **e2e-first-planner**: ユーザーストーリーからE2Eスライス生成、計画出力
 - **design-reviewer**: Playwright MCP連携、ブレークポイント別レビュー
+- **changelog-generator**: git/jjコミット履歴解析、CHANGELOG.md生成、バージョン提案、GitHub Releases作成支援
 
 ### プロジェクト用Claude設定
 - **プロジェクト最適化**: プロジェクト固有のワークフロー対応

--- a/install-global.sh
+++ b/install-global.sh
@@ -213,6 +213,12 @@ ensure_dir "$CLAUDE_DIR/skills/design-review"
 download_file "$REPO_URL/.claude/skills/design-review/SKILL.md" \
     "$CLAUDE_DIR/skills/design-review/SKILL.md" "Design Review Skill"
 
+# Changelog Skill
+echo "📥 Changelog Skillをダウンロード中..."
+ensure_dir "$CLAUDE_DIR/skills/changelog"
+download_file "$REPO_URL/.claude/skills/changelog/SKILL.md" \
+    "$CLAUDE_DIR/skills/changelog/SKILL.md" "Changelog Skill"
+
 # サブエージェントのダウンロード
 download_agent() {
     local agent=$1
@@ -238,6 +244,9 @@ download_agent "e2e-first-planner" "E2E First Planner"
 
 # Design Reviewer エージェント
 download_agent "design-reviewer" "Design Reviewer"
+
+# Changelog Generator エージェント
+download_agent "changelog-generator" "Changelog Generator"
 
 # 言語別Skillsのダウンロード
 download_skill() {


### PR DESCRIPTION
## 概要

CHANGELOGとリリースノート自動生成のためのスキルとエージェントを追加しました。

## 追加内容

### スキル
- `.claude/skills/changelog/SKILL.md` (480行)
  - Keep a Changelog形式の仕様
  - Conventional Commits規約
  - Semantic Versioningルール
  - git logからの情報抽出方法
  - 自動生成ツールの使用方法（conventional-changelog, standard-version, git-chglog）
  - ベストプラクティス
  - GitHub Releases連携

### エージェント
- `.claude/agents/changelog-generator/AGENT.md` (648行)
  - git/jujutsuコミット履歴の解析
  - Conventional Commits形式の分類
  - Keep a Changelog形式のCHANGELOG.md生成
  - Semantic Versioningに基づくバージョン提案
  - GitHub Releases用リリースノート作成支援
  - 安全性ルール（自動git操作禁止）

### インストールスクリプト
- `install-global.sh`
  - Changelog Skillのダウンロード処理追加
  - Changelog Generator エージェントのダウンロード処理追加

## 機能

- ✅ git/jujutsuコミット履歴の自動解析
- ✅ Conventional Commitsの分類（feat→Added, fix→Fixed等）
- ✅ Keep a Changelog形式のCHANGELOG.md生成
- ✅ Semantic Versioningに基づくバージョン番号提案
- ✅ Breaking Change検出とメジャーバージョンアップ判定
- ✅ GitHub Releases用リリースノート生成
- ✅ 複数の自動生成ツール対応

## テスト

- [x] ファイルが正しく作成されているか確認
- [x] YAMLフロントマターが正しいか確認
- [x] jjステータスで変更がトラッキングされているか確認
- [x] ファイルサイズと内容の確認

## 関連

- docs/tmp/plan.md のタスク5: "changelog-generatorエージェント (4-5時間) - リリースノート自動生成"
- 前回のPR: #18（4つのスキル・エージェントペア追加）、#19（README更新）

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * チェンジログの自動生成エージェントと関連スキルを追加しました。コミット履歴からCHANGELOGを生成・更新し、リリースノートやバージョン提案を支援します。

* **ドキュメント**
  * チェンジログ生成、Keep a Changelog、セマンティックバージョニング、コンベンショナルコミットに関する包括的なガイド（手順・例・ベストプラクティス）を追加しました。

* **その他**
  * インストール/配布手順とREADMEに新しいチェンジログ機能の記載を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->