### PR TITLE
feat: チーム標準にブランチ保護ルールを追加

### DIFF
--- a/.claude/team/CLAUDE-team-standards.md
+++ b/.claude/team/CLAUDE-team-standards.md
@@ -33,6 +33,10 @@
 - **bugfix/**: バグ修正用（developから分岐）
 - **hotfix/**: 緊急修正用（mainから分岐）
 
+**禁止事項:**
+- main/masterブランチへの直接push/commitは禁止
+- force push（`--force`, `-f`）の使用は禁止（特にmain/masterへは厳禁）
+
 **品質基準:**
 - テストカバレッジ95%以上を維持
 - 静的解析の警告はマージ前に解消


### PR DESCRIPTION
## Summary
- チーム開発標準にブランチ保護のための禁止事項セクションを追加
- main/masterブランチへの直接push/commitを禁止
- force push（`--force`, `-f`）の使用を禁止（特にmain/masterへは厳禁）

## 変更内容
`.claude/team/CLAUDE-team-standards.md`の「開発フロー原則」セクション内、ブランチ戦略の直後に以下を追加:

```markdown
**禁止事項:**
- main/masterブランチへの直接push/commitは禁止
- force push（`--force`, `-f`）の使用は禁止（特にmain/masterへは厳禁）
```

## 目的
- ブランチ戦略に基づいた安全な運用を強制
- 誤った操作による本番環境への影響を防止
- チーム全体でのGit運用ルールの明確化

## Test plan
- [ ] CLAUDE-team-standards.mdの変更内容を確認
- [ ] 禁止事項がブランチ戦略セクションの直後に正しく配置されていることを確認
- [ ] ドキュメントの文法と形式が適切であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

本リリースは内部プロセスの標準化に関する更新です。エンドユーザー向けの新機能やバグ修正はありません。

* **ドキュメント**
  * チーム標準に関するドキュメントの更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->