### PR TITLE
chore: development-toolkit v1.1.0 + バージョン管理ルール追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,15 @@ Error: Plugin has an invalid manifest file.
 Validation errors: Unrecognized key(s) in object: 'docs'
 ```
 
+### バージョン管理
+
+プラグイン関連のファイル（plugin.json, commands/, agents/, skills/, hooks/）を修正した場合は、必ずバージョンを更新すること。
+
+**Semantic Versioning:**
+- **MAJOR** (x.0.0): 破壊的変更（既存機能の削除・変更）
+- **MINOR** (0.x.0): 後方互換の新機能追加
+- **PATCH** (0.0.x): バグ修正・ドキュメント修正
+
 ## 開発原則
 
 - TDD 推奨、カバレッジ 95%+ 目標

--- a/plugins/development-toolkit/.claude-plugin/plugin.json
+++ b/plugins/development-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "development-toolkit",
   "description": "Complete development workflow: planning, coding, PR management, and changelog generation. Essential tools for daily development work.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "sk8metalme"
   },


### PR DESCRIPTION
## 変更内容

### 1. development-toolkit バージョン更新

- **1.0.0 → 1.1.0** (マイナーバージョン増加)
- **理由**: PR #41で secrets-guard スキルを追加（後方互換の新機能）

### 2. CLAUDE.md にバージョン管理ルール追記

プラグイン開発ガイドラインセクションに以下を追加：

```markdown
### バージョン管理

プラグイン関連のファイル（plugin.json, commands/, agents/, skills/, hooks/）を修正した場合は、必ずバージョンを更新すること。

**Semantic Versioning:**
- **MAJOR** (x.0.0): 破壊的変更（既存機能の削除・変更）
- **MINOR** (0.x.0): 後方互換の新機能追加
- **PATCH** (0.0.x): バグ修正・ドキュメント修正
```

## 影響範囲

- `plugins/development-toolkit/.claude-plugin/plugin.json`: バージョンフィールド更新
- `CLAUDE.md`: バージョン管理ガイドライン追加

## テスト計画

- [ ] プラグインマニフェストの検証
- [ ] ドキュメントの可読性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)