### PR TITLE
feat: improve create_pr command (upfront confirmation + review-dojo-mcp)

### DIFF
--- a/plugins/development-toolkit/.claude-plugin/plugin.json
+++ b/plugins/development-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "development-toolkit",
   "description": "Complete development workflow: planning, coding, PR management, and changelog generation. Essential tools for daily development work.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "sk8metalme"
   },


### PR DESCRIPTION
## Summary

Issue #44と#46の改善として、`create_pr`コマンドに**2つの重要な機能**を追加しました。

## Issue #44: 事前確認フェーズの追加

### 主な変更

- ✅ **ステップ0: 事前確認フェーズを追加**
  - ターゲットブランチの確認（main / develop / その他）
  - バージョン更新方針の確認（スキップ / PATCH / MINOR / MAJOR）
  - **ユーザーへの確認項目を最初にまとめて実施**することで、作業フローの中断を最小化

- ✅ **ステップ3: バージョン更新の実施**
  - ステップ0で決めた方針に基づいてバージョンを更新
  - バージョンファイル検出ロジックをステップ3に統合

- ✅ **ステップ5: PR作成**
  - ステップ0で確認したターゲットブランチを使用

### 改善効果

- ユーザーは最初にすべての確認項目に答え、その後は自動で処理が進む
- 作業フローの中断が最小化され、ユーザー体験が向上

## Issue #46: review-dojo-mcp統合

### 主な変更

- ✅ **ステップ2: review-dojo-mcp統合を追加**
  - `generate_pr_checklist`で過去のレビュー知見を取得
  - 取得した知見をレビューの参考情報として表示
  - `/review`と`/security-review`で知見を考慮

- ✅ **オプショナル機能**
  - review-dojo-mcpが利用可能な場合のみ動作
  - 利用不可でもエラーにならない

### 改善効果

- 過去のレビュー知見を活用して品質向上
- 繰り返しの問題を防止
- チームのベストプラクティスを自動的に参照

## バージョン更新

- development-toolkitのバージョンを1.2.0から1.4.0へ更新（MINOR）

## 参考

- review-dojo-mcp: https://github.com/sk8metalme/review-dojo-mcp

Closes #44
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)