### PR TITLE
fix: development-toolkit plugin の SessionEnd hook を無効化

### DIFF
--- a/plugins/development-toolkit/.claude-plugin/plugin.json
+++ b/plugins/development-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "development-toolkit",
   "description": "Complete development workflow: planning, coding, PR management, and changelog generation. Essential tools for daily development work.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "sk8metalme"
   },
@@ -26,27 +26,5 @@
     "./skills/changelog/SKILL.md",
     "./skills/secrets-guard/SKILL.md",
     "./skills/mermaid-validator/SKILL.md"
-  ],
-  "hooks": {
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/suggest-claude-md-hook-global.sh"
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/suggest-claude-md-hook-global.sh"
-          }
-        ]
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

`development-toolkit` プラグインの SessionEnd/PreCompact hooks を削除しました。

これらのフックは `.claude/commands/suggest-claude-md.md` ファイルの存在を前提としていましたが、プロジェクトレベルでこのファイルが存在しない場合にエラーが発生していました。

## Changes

- ❌ `hooks.SessionEnd` セクションを削除
- ❌ `hooks.PreCompact` セクションを削除  
- 🔼 バージョンを `1.5.0` → `1.5.1` に更新

## Modified Files

- `plugins/development-toolkit/.claude-plugin/plugin.json`

## Impact

- ✅ SessionEnd/PreCompact 時のエラーメッセージが表示されなくなる
- ℹ️ `/suggest-claude-md` コマンドは引き続き手動で実行可能

## Test Plan

- [x] plugin.json の JSON 構文が正しいことを確認
- [x] 必須フィールドがすべて保持されていることを確認
- [x] バージョン番号が適切に更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 特定のフック設定を削除し、セッション終了時とコンパクト前の自動実行機能を廃止しました。

* **Chores**
  * バージョンを 1.5.0 から 1.5.1 にアップデートしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->