### PR TITLE
fix: remove hanging ccusage from statusLine command

### DIFF
--- a/global/settings.template.json
+++ b/global/settings.template.json
@@ -253,7 +253,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "echo \"$(pwd | sed \"s|^$HOME|~|\") [$(git branch --show-current 2>/dev/null || echo '-')] | $(bun x ccusage statusline)\"",
+    "command": "echo \"$(pwd | sed \"s|^$HOME|~|\") [$(git branch --show-current 2>/dev/null || echo '-')]\"",
     "padding": 0
   },
   "git": {


### PR DESCRIPTION
## Summary

`bun x ccusage statusline` がタイムアウトして statusLine 全体が失敗するため、ディレクトリとブランチだけを表示するシンプルな設定に変更しました。

## 問題

現在の statusLine コマンドに含まれる `bun x ccusage statusline` の部分がタイムアウトし、結果として statusLine 全体が機能しなくなっていました。

## 解決策

ccusage の呼び出しを削除し、以下の情報のみを表示するシンプルな設定に変更：
- カレントディレクトリ（`~` に省略）
- git ブランチ名

## 変更内容

**Before:**
```bash
echo "$(pwd | sed "s|^$HOME|~|") [$(git branch --show-current 2>/dev/null || echo '-')] | $(bun x ccusage statusline)"
```

**After:**
```bash
echo "$(pwd | sed "s|^$HOME|~|") [$(git branch --show-current 2>/dev/null || echo '-')]"
```

## 影響範囲

- `global/settings.template.json` の statusLine 設定のみ
- 次回 `./install-global.sh` 実行時に反映される

## Test plan

- [x] 修正後のコマンドが正常に動作することを確認
- [x] ディレクトリとブランチが正しく表示されることを確認
- [x] タイムアウトが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更**
  * statusLine コマンドを簡略化し、現在のディレクトリと Git ブランチ情報のみを表示するようにしました。追加のステータス情報は削除されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->