### PR TITLE
fix: add skills arrays to marketplace.json for Skills slash command support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,73 +9,85 @@
       "name": "jujutsu-workflow",
       "source": "./plugins/jujutsu-workflow",
       "description": "Jujutsu version control workflow support",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/jujutsu"]
     },
     {
       "name": "development-toolkit",
       "source": "./plugins/development-toolkit",
       "description": "Complete development workflow: planning, coding, PR management, and changelog generation",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/changelog", "./skills/secrets-guard", "./skills/mermaid-validator"]
     },
     {
       "name": "ci-cd-tools",
       "source": "./plugins/ci-cd-tools",
       "description": "CI/CD troubleshooting and GitHub Actions support",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/ci-cd"]
     },
     {
       "name": "oss-compliance",
       "source": "./plugins/oss-compliance",
       "description": "OSS license compliance checking and auditing",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/oss-license"]
     },
     {
       "name": "version-audit",
       "source": "./plugins/version-audit",
       "description": "Technology stack version auditing and EOL checking",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/stable-version"]
     },
     {
       "name": "design-review",
       "source": "./plugins/design-review",
       "description": "UI/UX design review and accessibility checking",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/design-review"]
     },
     {
       "name": "e2e-planning",
       "source": "./plugins/e2e-planning",
       "description": "E2E-first development planning and Walking Skeleton design",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/e2e-first-planning"]
     },
     {
       "name": "lang-java-spring",
       "source": "./plugins/lang-java-spring",
       "description": "Java + Spring Boot development support",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/java-spring"]
     },
     {
       "name": "lang-python",
       "source": "./plugins/lang-python",
       "description": "Python + FastAPI development support",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/python"]
     },
     {
       "name": "lang-php",
       "source": "./plugins/lang-php",
       "description": "PHP + Slim Framework development support",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/php"]
     },
     {
       "name": "lang-perl",
       "source": "./plugins/lang-perl",
       "description": "Perl + Mojolicious development support",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "skills": ["./skills/perl"]
     },
     {
       "name": "deep-dive",
       "source": "./plugins/deep-dive",
       "description": "Deep-dive skill for recursive requirement exploration",
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "skills": ["./skills/deep-dive"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

marketplace.jsonに全プラグインの`skills`配列を追加し、Skillsスラッシュコマンド（`/deep-dive`, `/java-spring`等）が正常に動作するようにしました。

## Background

- `/deep-dive`, `/java-spring`等のSkillsコマンドが「Unknown skill」エラーで動作しない問題が発生
- 公式プラグイン（anthropic-agent-skills）との構造比較により、marketplace.jsonに`skills`配列が必要であることが判明

## Changes

全12プラグインに`skills`配列を追加:
- jujutsu-workflow, development-toolkit（3スキル）, ci-cd-tools
- oss-compliance, version-audit, design-review, e2e-planning
- lang-java-spring, lang-python, lang-php, lang-perl, deep-dive

## Test Plan

1. プラグイン再インストール: `/plugin marketplace refresh`
2. Skillsコマンド確認: `/deep-dive`, `/java-spring`, `/ci-cd`
3. 期待結果: 「Unknown skill」エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プラグイン設定に新たにスキル情報フィールドを追加しました。全プラグインに関連するスキル定義への参照が整理され、スキル管理がより効率的になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->