### PR TITLE
feat(quizknock): add haiku model for faster quiz generation (v1.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,7 +103,7 @@
       "name": "quizknock",
       "source": "./plugins/quizknock",
       "description": "Interactive quiz generation for learning reinforcement",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "skills": ["./skills/quizknock"]
     }
   ]

--- a/plugins/quizknock/.claude-plugin/plugin.json
+++ b/plugins/quizknock/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quizknock",
   "description": "Interactive quiz generation for learning reinforcement. Uses subagent research and AskUserQuestion for 5-question quiz sets with statistics and review.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "sk8metalme"
   },

--- a/plugins/quizknock/skills/quizknock/SKILL.md
+++ b/plugins/quizknock/skills/quizknock/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: quizknock
 description: "指定トピックの理解を深めるクイズを出題。サブエージェントで詳細調査後、AskUserQuestionで選択式クイズを5問ずつ出題。統計表示と間違った問題の復習支援。トリガー: 「クイズ」「理解度チェック」「テストして」「クイズで確認」。"
+model: haiku
 allowed-tools: AskUserQuestion, Task, Read, Grep, Glob
 ---
 


### PR DESCRIPTION
## Summary
- Add `model: haiku` to quizknock skill for faster quiz generation
- Update plugin version from 1.0.0 to 1.1.0 (MINOR version bump)
- Sync marketplace.json version

## Changes
1. **SKILL.md**: Added `model: haiku` to frontmatter
2. **plugin.json**: Version 1.0.0 → 1.1.0
3. **marketplace.json**: Version 1.0.0 → 1.1.0

## Benefits
- ⚡ **Faster response**: haiku model provides quicker quiz generation
- 💰 **Cost-effective**: Lower API costs per quiz session
- ✅ **Backward compatible**: All existing functionality preserved

## Test plan
- [ ] Install updated plugin: `/plugin marketplace refresh && /plugin install quizknock@ai-agent-setup`
- [ ] Run quiz: `/quizknock TypeScript`
- [ ] Verify faster response time compared to sonnet
- [ ] Confirm AskUserQuestion works correctly
- [ ] Check quiz quality remains acceptable

## Version bump rationale
- **MINOR (1.0.0 → 1.1.0)**: Backward-compatible performance enhancement
- No breaking changes to API or functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スキルメタデータに新しいフィールドを追加

* **アップデート**
  * プラグインバージョンを1.1.0に更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->