### PR TITLE
feat(daily-knowledge-sync): v2.1.0 - ファイル名ルールをkebab-case・英語に変更

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -136,7 +136,7 @@
       "name": "daily-knowledge-sync",
       "source": "./plugins/daily-knowledge-sync",
       "description": "Automatically extract and sync knowledge from daily Claude Code conversations to a GitHub repository.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "skills": [
         "./skills/daily-knowledge-sync"
       ]

--- a/plugins/daily-knowledge-sync/.claude-plugin/plugin.json
+++ b/plugins/daily-knowledge-sync/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "daily-knowledge-sync",
   "description": "Automatically extract and sync knowledge from daily Claude Code conversations to a GitHub repository.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "sk8metalme"
   },

--- a/plugins/daily-knowledge-sync/skills/daily-knowledge-sync/SKILL.md
+++ b/plugins/daily-knowledge-sync/skills/daily-knowledge-sync/SKILL.md
@@ -434,7 +434,14 @@ Claude Code自身が詳細評価します。
 | decision | "accept" / "reject" |
 | category | "errors" / "ops" / "domain" |
 | title | 知識タイトル（acceptの場合） |
+| filename | ファイル名ベース（kebab-case、英語、50文字以内、日付・拡張子なし） |
 | reason | 判定理由（20文字以内） |
+
+**filename 生成ルール**:
+- 英語で記述（日本語タイトルは意味を保って英訳）
+- kebab-case（ハイフン区切り、小文字）
+- 50文字以内
+- 日付・拡張子は含めない
 
 **採用基準（accept）**:
 - **文字数**: 200文字以上（`_should_exclude`で自動チェック）

--- a/plugins/daily-knowledge-sync/skills/daily-knowledge-sync/scripts/categorize_knowledge.py
+++ b/plugins/daily-knowledge-sync/skills/daily-knowledge-sync/scripts/categorize_knowledge.py
@@ -89,21 +89,35 @@ class KnowledgeCategorizer:
         else:
             return DEFAULT_CATEGORY
 
-    def generate_filename(self, title: str, date: str) -> str:
+    def generate_filename(
+        self, title: str, date: str, provided_filename: str | None = None
+    ) -> str:
         """
         Generate a filename from title and date.
 
         Args:
             title: Knowledge item title
             date: Date in YYYY-MM-DD format
+            provided_filename: Optional kebab-case English filename (without date/extension)
 
         Returns:
-            str: Filename (e.g., "2026-01-31_fix_import_error.md")
+            str: Filename (e.g., "2026-01-31_fix-import-error.md")
         """
-        # Clean title for filename
-        clean_title = re.sub(r"[^\w\s-]", "", title.lower())
-        clean_title = re.sub(r"[\s_]+", "_", clean_title)
-        clean_title = clean_title[:50]  # Limit length
+        if provided_filename:
+            # 提供されたファイル名を使用（kebab-case、英語）
+            clean_title = re.sub(r"[^a-z0-9-]", "", provided_filename.lower())
+            clean_title = re.sub(r"-+", "-", clean_title).strip("-")
+        else:
+            # フォールバック: ASCII文字のみ + kebab-case
+            clean_title = re.sub(r"[^\x00-\x7F]+", "", title)
+            clean_title = clean_title.lower()
+            clean_title = re.sub(r"[^\w\s-]", "", clean_title)
+            clean_title = re.sub(r"[\s_]+", "-", clean_title)
+            clean_title = re.sub(r"-+", "-", clean_title).strip("-")
+
+        clean_title = clean_title[:50]
+        if not clean_title:
+            clean_title = "untitled"
 
         return f"{date}_{clean_title}.md"
 

--- a/plugins/daily-knowledge-sync/skills/daily-knowledge-sync/scripts/create_knowledge_files.py
+++ b/plugins/daily-knowledge-sync/skills/daily-knowledge-sync/scripts/create_knowledge_files.py
@@ -87,6 +87,7 @@ class KnowledgeFileCreator:
             candidate = candidate_map[index]
             category = evaluation["category"]
             title = evaluation["title"]
+            filename = evaluation.get("filename")
             text = candidate["text"]
 
             # Check similarity with existing knowledge
@@ -102,6 +103,7 @@ class KnowledgeFileCreator:
                 text=text,
                 timestamp=candidate["timestamp"],
                 project_path=candidate.get("project_path", ""),
+                provided_filename=filename,
             )
 
             if file_path:
@@ -152,6 +154,7 @@ class KnowledgeFileCreator:
         text: str,
         timestamp: str,
         project_path: str = "",
+        provided_filename: str | None = None,
     ) -> Path | None:
         """
         Create a knowledge markdown file.
@@ -162,6 +165,7 @@ class KnowledgeFileCreator:
             text: Knowledge content
             timestamp: ISO timestamp
             project_path: Project path (optional)
+            provided_filename: Optional kebab-case English filename (optional)
 
         Returns:
             Path | None: Created file path or None on error
@@ -169,10 +173,10 @@ class KnowledgeFileCreator:
         category_dir = self.repo_path / category
         category_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate filename using categorizer (YYYY-MM-DD_snake_case.md format)
+        # Generate filename using categorizer (YYYY-MM-DD_kebab-case.md format)
         dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
         date = dt.strftime("%Y-%m-%d")
-        filename = self.categorizer.generate_filename(title, date)
+        filename = self.categorizer.generate_filename(title, date, provided_filename)
         file_path = category_dir / filename
 
         # Avoid overwriting existing files


### PR DESCRIPTION
## 概要

daily-knowledge-sync プラグインのファイル名ルールを **kebab-case、英語、50文字以内** に変更しました。

**変更前**: `2026-01-13_claude_code_フックの実行タイミング_-_sessionend_vs_stop.md`
**変更後**: `2026-01-13_claude-code-hook-timing-sessionend-vs-stop.md`

## 変更内容

### 修正ファイル（5ファイル）

1. **categorize_knowledge.py** - `generate_filename` に `provided_filename` パラメータ追加
2. **create_knowledge_files.py** - 評価結果から `filename` を読み取り渡す処理を追加
3. **SKILL.md** - 評価項目に `filename` フィールドを追加
4. **plugin.json** - バージョン 2.0.0 → 2.1.0
5. **marketplace.json** - バージョン同期

## テスト計画

- プラグイン再インストール
- 知識同期を実行して filename が kebab-case で生成されることを確認

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**バージョン 2.1.0**

* **新機能**
  * ナレッジファイルにカスタムファイル名指定機能を追加
  * ファイル名の自動生成ルールを導入（英語、ケバブケース、50文字制限）

* **改善**
  * プラグインバージョンを2.1.0へ更新
  * ファイル名生成プロセスを最適化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->